### PR TITLE
Remove trailing slash in allowedOrigins

### DIFF
--- a/lib/handlers/ProjectCreateHandler.js
+++ b/lib/handlers/ProjectCreateHandler.js
@@ -79,7 +79,7 @@ class ProjectCreateHandler {
 				branch: 'master'
 			},
 			cors: {
-				allowedOrigins: ['https://functions.azure.com/'] // Allows the portal to talk to the function app
+				allowedOrigins: ['https://functions.azure.com'] // Allows the portal to talk to the function app
 			},
 			containerSize: 128
 		};


### PR DESCRIPTION
The trailing slashes messes up the cors workflow from Azure portal
