### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/lib/templates/project/f-resources-arm.json
+++ b/lib/templates/project/f-resources-arm.json
@@ -110,7 +110,6 @@
 						"AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]",
 						"AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]",
 						"WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]",
-						"AZUREJOBS_EXTENSION_VERSION": "beta",
 						"FUNCTIONS_EXTENSION_VERSION": "~0.5",
 						"SCM_REPOSITORY_PATH": "wwwroot"
 					}


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.